### PR TITLE
move formats check to optimize service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
-  "name": "rupolka-snippet",
-  "version": "0.0.1",
+  "name": "image-optimize",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "rupolka-snippet",
-      "version": "0.0.1",
-      "license": "UNLICENSED",
+      "name": "image-optimize",
+      "version": "0.1.8",
+      "license": "MIT",
       "dependencies": {
         "@digikare/nestjs-prom": "=1.0.0",
         "@nestjs/common": "=7.6.18",
-        "@nestjs/config": "^0.6.3",
         "@nestjs/core": "=7.6.18",
         "@nestjs/platform-express": "=7.6.18",
         "node-fetch": "=2.6.1",
@@ -1437,24 +1436,6 @@
         "class-validator": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nestjs/config": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-0.6.3.tgz",
-      "integrity": "sha512-JxvvUpmH0/WOrTB+zh8dEkxSUQXhB7V3d/qeQXyCnMiEFjaq89+fNFztpWjz4DlOfdS4/eYTzIEy9PH2uGnfzA==",
-      "dependencies": {
-        "dotenv": "8.2.0",
-        "dotenv-expand": "5.1.0",
-        "lodash.get": "4.4.2",
-        "lodash.has": "4.5.2",
-        "lodash.set": "4.3.2",
-        "uuid": "8.3.2"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "^6.10.0 || ^7.0.0",
-        "reflect-metadata": "^0.1.12",
-        "rxjs": "^6.0.0"
       }
     },
     "node_modules/@nestjs/core": {
@@ -3706,19 +3687,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -6809,26 +6777,11 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "node_modules/lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "node_modules/lodash.toarray": {
       "version": "4.4.0",
@@ -10963,19 +10916,6 @@
         "uuid": "8.3.2"
       }
     },
-    "@nestjs/config": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-0.6.3.tgz",
-      "integrity": "sha512-JxvvUpmH0/WOrTB+zh8dEkxSUQXhB7V3d/qeQXyCnMiEFjaq89+fNFztpWjz4DlOfdS4/eYTzIEy9PH2uGnfzA==",
-      "requires": {
-        "dotenv": "8.2.0",
-        "dotenv-expand": "5.1.0",
-        "lodash.get": "4.4.2",
-        "lodash.has": "4.5.2",
-        "lodash.set": "4.3.2",
-        "uuid": "8.3.2"
-      }
-    },
     "@nestjs/core": {
       "version": "7.6.18",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-7.6.18.tgz",
@@ -12756,16 +12696,6 @@
           "dev": true
         }
       }
-    },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-    },
-    "dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -15119,26 +15049,11 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.toarray": {
       "version": "4.4.0",

--- a/src/controllers/optimize-controller/optimize.controller.ts
+++ b/src/controllers/optimize-controller/optimize.controller.ts
@@ -48,13 +48,6 @@ export class OptimizeController {
             throw new BadRequestException("Parameter 'format' is required.");
         }
 
-        const formats = ["jpeg", "png", "webp", "avif"];
-        if (!formats.includes(format)) {
-            throw new BadRequestException(
-                "Parameter 'format' is not supported.",
-            );
-        }
-
         const nQuality = quality ? Number.parseInt(quality) : void 0;
         if (nQuality !== void 0) {
             if (isNaN(nQuality)) {

--- a/src/services/optimize.service.ts
+++ b/src/services/optimize.service.ts
@@ -1,6 +1,8 @@
-import { Injectable } from "@nestjs/common";
+import {BadRequestException, Injectable} from '@nestjs/common';
 import * as sharp from "sharp"; // http://sharp.pixelplumbing.com/en/stable/api-constructor/ , https://developers.google.com/speed/webp/docs/cwebp
 import fetch, { Headers } from "node-fetch";
+
+const FORMATS: ReadonlyArray<string> = ["jpeg", "png", "webp", "avif"];
 
 @Injectable()
 export class OptimizeService {
@@ -10,6 +12,12 @@ export class OptimizeService {
         format: string,
         quality?: number,
     ): Promise<Buffer> {
+        if (!FORMATS.includes(format.toLowerCase())) {
+            throw new BadRequestException(
+                "Parameter 'format' is not supported.",
+            );
+        }
+
         const data = await this.getImage(src);
 
         let img = sharp(data).resize({ width: intSize });


### PR DESCRIPTION
Перенёс проверку форматов в сервис optimize, т.к. на мой взгляд информация о формате картинок должна хранится в одном месте (в сервисе) и контролер не должен знать про эту бизнес логику.
Плюс еще добавил toLowerCase(). чтобы работали в т.ч. форматы PNG